### PR TITLE
#Prod | Feat modulo salida

### DIFF
--- a/GroupTours/apps/paquete/migrations/0018_populate_codigo_salida_paquete.py
+++ b/GroupTours/apps/paquete/migrations/0018_populate_codigo_salida_paquete.py
@@ -1,0 +1,32 @@
+from django.db import migrations
+
+
+def generar_codigos(apps, schema_editor):
+    SalidaPaquete = apps.get_model("paquete", "SalidaPaquete")
+
+    salidas_sin_codigo = SalidaPaquete.objects.filter(codigo__isnull=True).order_by("fecha_creacion", "id")
+
+    for salida in salidas_sin_codigo:
+        year = salida.fecha_creacion.year
+        ultimo_num = SalidaPaquete.objects.filter(
+            fecha_creacion__year=year,
+            codigo__startswith=f"SAL-{year}-"
+        ).count() + 1
+        salida.codigo = f"SAL-{year}-{ultimo_num:04d}"
+        salida.save(update_fields=["codigo"])
+
+
+def revertir_codigos(apps, schema_editor):
+    SalidaPaquete = apps.get_model("paquete", "SalidaPaquete")
+    SalidaPaquete.objects.update(codigo=None)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("paquete", "0017_add_codigo_to_salida_paquete"),
+    ]
+
+    operations = [
+        migrations.RunPython(generar_codigos, revertir_codigos),
+    ]


### PR DESCRIPTION
 Resumen                                                                                                                                                                     
                                                                                                                                                                              
  - Migración de datos 0018: genera códigos SAL-{año}-{número} para todos los registros existentes de SalidaPaquete que tengan codigo=NULL, evitando que los datos históricos 
  queden sin identificador tras el deploy.
  - Complementa la migración 0017 que agrega el campo codigo al modelo.
  - Incluye operación de reversa (limpia los códigos a NULL si se hace rollback).

  Test plan

  - Ejecutar python manage.py migrate y verificar que 0017 y 0018 corren sin errores
  - Confirmar en base de datos que ningún registro de SalidaPaquete queda con codigo=NULL
  - Verificar que los códigos generados siguen el formato SAL-{año}-{número} y son únicos
  - Crear una nueva salida desde el endpoint y confirmar que el código se genera correctamente sin colisionar con los existentes